### PR TITLE
Disable cache

### DIFF
--- a/api/now-playing.ts
+++ b/api/now-playing.ts
@@ -23,8 +23,8 @@ export default async function (req: NowRequest, res: NowResponse) {
     return res.status(200).end();
   }
 
-  res.setHeader("Content-Type", "image/svg+xml");
-  res.setHeader("Cache-Control", "s-maxage=1, stale-while-revalidate");
+  // res.setHeader("Content-Type", "image/svg+xml");
+  // res.setHeader("Cache-Control", "s-maxage=1, stale-while-revalidate");
 
   const { duration_ms: duration, name: track } = item;
   const { images = [] } = item.album || {};


### PR DESCRIPTION
For fresher images. 

According to the [docs](https://vercel.com/docs/edge-network/caching), if we set `Cache-Control` on the lambda, then it will use caching. 